### PR TITLE
Upgrade @actions/cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && NODE_OPTIONS=--openssl-legacy-provider ncc build -o dist/ src/index.ts"
   },
   "devDependencies": {
-    "@actions/cache": "^1.0.6",
+    "@actions/cache": "^4.0.0",
     "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
     "@actions/glob": "^0.1.1",


### PR DESCRIPTION
Dependency installation using this action is failing with the following error:
```
Warning: Error: Cache service responded with 422
    at Object.<anonymous> (/home/runner/work/_actions/trilogy-group/action-npm-install-dependencies/v1/dist/index.js:250:19)
    at Generator.next (<anonymous>)
    at fulfilled (/home/runner/work/_actions/trilogy-group/action-npm-install-dependencies/v1/dist/index.js:174:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

See for example: https://github.com/trilogy-group/worksmart-ts/actions/runs/14514083564/job/40719614807

According to this announcement https://github.com/actions/toolkit/discussions/1890, we should upgrade to v4